### PR TITLE
fix: content scrolling when content is short

### DIFF
--- a/src/components/prefabs/scrollable-container.component.ts
+++ b/src/components/prefabs/scrollable-container.component.ts
@@ -267,7 +267,8 @@ export const scrollableContainer: ContainerComponent<
     });
 
     const moveScrollFunction = (increment: number = 1) => {
-      if (!scrollContainer.getVisible()) return;
+      if (!scrollContainer.getVisible() || !scrollSelector?.getVisible())
+        return;
 
       const $size = $content.getBounds()[sizeStr] - size[sizeStr];
       $content[pivotFuncStr]((value) => {


### PR DESCRIPTION
## Before
![tulip-scroll-before](https://github.com/user-attachments/assets/c4326f3b-1c17-4716-b288-9e95266d4da9)

## After
![tulip-scroll-after](https://github.com/user-attachments/assets/857fa067-7ac9-464d-b253-d688e0cb7e1a)

Self explanatory, there was a bug where "short" content would still get scrolled, having a weird visual behaviour