### PR TITLE
Feat/input text sprite key combo

### DIFF
--- a/examples/example/src/app.component.ts
+++ b/examples/example/src/app.component.ts
@@ -2,10 +2,10 @@ import { container, ContainerComponent } from "@tu/tulip";
 import { dataComponent } from "data.component";
 // import { testComponent } from "test.component";
 // import { textsComponent } from "texts.component";
-// import {inputsComponent} from "inputs.component";
+import { inputsComponent } from "inputs.component";
 // import { playerComponent } from "player.component";
 // import { dragComponent } from "drag.component";
-import { scrollablesComponent } from "./scrollables.component";
+// import { scrollablesComponent } from "./scrollables.component";
 // import { testComponent } from "./test.component";
 
 type Props = {};
@@ -14,11 +14,11 @@ type Mutable = {};
 export const appComponent: ContainerComponent<Props, Mutable> = () => {
   const $container = container({ label: "app" });
 
-  // $container.add(textsComponent());
+  //$container.add(textsComponent());
   // $container.add(playerComponent());
-  // $container.add(inputsComponent());
+  $container.add(inputsComponent());
   // $container.add(dragComponent());
-  $container.add(scrollablesComponent());
+  // $container.add(scrollablesComponent());
   // $container.add(testComponent());
 
   const a = dataComponent({ test: "Abc12312311333" });

--- a/src/components/prefabs/input-text-sprite.component.ts
+++ b/src/components/prefabs/input-text-sprite.component.ts
@@ -2,6 +2,7 @@ import {
   ContainerComponent,
   InputTextSpriteMutable,
   InputTextSpriteProps,
+  KeyComboEvent,
   PartialInputTextSpriteProps,
 } from "../../types";
 import { container, graphics } from "../core";
@@ -278,15 +279,111 @@ export const inputTextSprite: ContainerComponent<
   };
 
   let currentAccentCode;
+  const getKeyCombination = ({
+    key,
+    altKey,
+    ctrlKey,
+    shiftKey,
+    metaKey,
+  }: KeyComboEvent): string => {
+    const keys: string[] = [];
+    if (altKey) keys.push("Alt");
+    if (ctrlKey) keys.push("Ctrl");
+    if (shiftKey) keys.push("Shift");
+    if (metaKey) keys.push("Meta");
+    keys.push(key);
+    return keys.join("+");
+  };
+
+  const keyCombinationHandlers: Record<string, () => void> = {
+    "Alt+ArrowLeft": () => {
+      if (!$editable || $text.length === 0) return;
+      const currentPos = getCursorPosition();
+      if (currentPos === 0) return;
+
+      let newPos = currentPos - 1;
+      while (newPos > 0 && $text[newPos] === " ") {
+        newPos--;
+      }
+      while (newPos > 0 && $text[newPos - 1] !== " ") {
+        newPos--;
+      }
+      setCursorPosition(newPos);
+    },
+
+    "Alt+ArrowRight": () => {
+      if (!$editable || $text.length === 0) return;
+      const currentPos = getCursorPosition();
+      if (currentPos === $text.length) return;
+
+      let newPos = currentPos;
+      while (newPos < $text.length && $text[newPos] === " ") {
+        newPos++;
+      }
+      while (newPos < $text.length && $text[newPos] !== " ") {
+        newPos++;
+      }
+      setCursorPosition(newPos);
+    },
+    "Alt+Backspace": () => {
+      if (!$editable || $text.length === 0) return;
+      const currentPos = getCursorPosition();
+      if (currentPos === 0) return;
+
+      let start = currentPos - 1;
+      while (start > 0 && $text[start] === " ") {
+        start--;
+      }
+      while (start > 0 && $text[start - 1] !== " ") {
+        start--;
+      }
+      $text = $text.slice(0, start) + $text.slice(currentPos);
+      $textSprite.setText($getCurrentText());
+      setCursorPosition(start);
+    },
+
+    "Alt+Delete": () => {
+      if (!$editable || $text.length === 0) return;
+      const currentPos = getCursorPosition();
+      if (currentPos === $text.length) return;
+
+      let end = currentPos;
+      while (end < $text.length && $text[end] === " ") {
+        end++;
+      }
+      while (end < $text.length && $text[end] !== " ") {
+        end++;
+      }
+      $text = $text.slice(0, currentPos) + $text.slice(end);
+      $textSprite.setText($getCurrentText());
+      setCursorPosition(currentPos);
+    },
+  };
+
   const onKeyDown = async ({
     key,
     metaKey,
     ctrlKey,
     code,
+    altKey,
     shiftKey,
   }: KeyboardEvent) => {
-    if (key === "Tab") return;
-    if ((metaKey || ctrlKey) && key.toLowerCase() === "v") return;
+    let mutableKey = key;
+
+    const combination = getKeyCombination({
+      key,
+      altKey,
+      ctrlKey,
+      shiftKey,
+      metaKey,
+    });
+    if (keyCombinationHandlers[combination]) {
+      keyCombinationHandlers[combination]();
+      return;
+    }
+
+    if (mutableKey === "Tab") return;
+    if ((metaKey || ctrlKey) && mutableKey.toLowerCase() === "v") return;
 
     const accentCode = getAccentCode(code, shiftKey);
     if (accentCode) {
@@ -294,14 +391,14 @@ export const inputTextSprite: ContainerComponent<
       return;
     }
     if (currentAccentCode) {
-      const combinedChar = combineAccentAndChar(currentAccentCode, key);
-      if (combinedChar) key = combinedChar;
+      const combinedChar = combineAccentAndChar(currentAccentCode, mutableKey);
+      if (combinedChar) mutableKey = combinedChar;
       currentAccentCode = "";
     }
 
     $stopCursorBlink();
-    writeText(key);
-    makeActions(key);
+    writeText(mutableKey);
+    makeActions(mutableKey);
   };
 
   const makeActions = (key: string) => {

--- a/src/components/prefabs/input-text-sprite.component.ts
+++ b/src/components/prefabs/input-text-sprite.component.ts
@@ -14,6 +14,7 @@ import {
   EventMode,
   GraphicType,
   HorizontalAlign,
+  OS,
   VerticalAlign,
 } from "../../enums";
 import {
@@ -21,6 +22,7 @@ import {
   combineAccentAndChar,
   getAccentCode,
   getInputElement,
+  getOS,
   isNotNullish,
   openKeyboard,
 } from "../../utils";
@@ -279,6 +281,10 @@ export const inputTextSprite: ContainerComponent<
   };
 
   let currentAccentCode;
+
+  const isMacOS = getOS() === OS.DARWIN;
+  const osNavigationModifier = isMacOS ? "Alt" : "Ctrl";
+
   const getKeyCombination = ({
     key,
     altKey,
@@ -296,7 +302,7 @@ export const inputTextSprite: ContainerComponent<
   };
 
   const keyCombinationHandlers: Record<string, () => void> = {
-    "Alt+ArrowLeft": () => {
+    [`${osNavigationModifier}+ArrowLeft`]: () => {
       if (!$editable || $text.length === 0) return;
       const currentPos = getCursorPosition();
       if (currentPos === 0) return;
@@ -311,7 +317,7 @@ export const inputTextSprite: ContainerComponent<
       setCursorPosition(newPos);
     },
 
-    "Alt+ArrowRight": () => {
+    [`${osNavigationModifier}+ArrowRight`]: () => {
       if (!$editable || $text.length === 0) return;
       const currentPos = getCursorPosition();
       if (currentPos === $text.length) return;
@@ -325,7 +331,7 @@ export const inputTextSprite: ContainerComponent<
       }
       setCursorPosition(newPos);
     },
-    "Alt+Backspace": () => {
+    [`${osNavigationModifier}+Backspace`]: () => {
       if (!$editable || $text.length === 0) return;
       const currentPos = getCursorPosition();
       if (currentPos === 0) return;
@@ -342,7 +348,7 @@ export const inputTextSprite: ContainerComponent<
       setCursorPosition(start);
     },
 
-    "Alt+Delete": () => {
+    [`${osNavigationModifier}+Delete`]: () => {
       if (!$editable || $text.length === 0) return;
       const currentPos = getCursorPosition();
       if (currentPos === $text.length) return;

--- a/src/components/prefabs/input-text-sprite.component.ts
+++ b/src/components/prefabs/input-text-sprite.component.ts
@@ -307,32 +307,39 @@ export const inputTextSprite: ContainerComponent<
   const makeActions = (key: string) => {
     if (!$editable || $text.length === 0) return;
 
-    if (key === "Backspace" && $cursorIndex > 0) {
-      $text = $text.slice(0, $cursorIndex - 1) + $text.slice($cursorIndex);
+    const currentPos = getCursorPosition();
+
+    if (key === "Backspace" && currentPos > 0) {
+      $text = $text.slice(0, currentPos - 1) + $text.slice(currentPos);
       $textSprite.setText($getCurrentText());
-
-      $cursorIndex--;
-      calcCursorPosition();
+      setCursorPosition(currentPos - 1);
       return;
     }
 
-    if (key === "Delete" && $cursorIndex < $text.length) {
-      $text = $text.slice(0, $cursorIndex) + $text.slice($cursorIndex + 1);
+    if (key === "Delete" && currentPos < $text.length) {
+      $text = $text.slice(0, currentPos) + $text.slice(currentPos + 1);
       $textSprite.setText($getCurrentText());
-
-      calcCursorPosition();
+      setCursorPosition(currentPos);
       return;
     }
 
-    if (key === "ArrowLeft" && $cursorIndex > 0) {
-      $cursorIndex--;
-      calcCursorPosition();
+    if (key === "ArrowLeft" && currentPos > 0) {
+      setCursorPosition(currentPos - 1);
       return;
     }
 
-    if (key === "ArrowRight" && $cursorIndex < $text.length) {
-      $cursorIndex++;
-      calcCursorPosition();
+    if (key === "ArrowRight" && currentPos < $text.length) {
+      setCursorPosition(currentPos + 1);
+      return;
+    }
+
+    if (key === "Home") {
+      setCursorPosition(0);
+      return;
+    }
+
+    if (key === "End") {
+      setCursorPosition($text.length);
       return;
     }
   };
@@ -371,6 +378,16 @@ export const inputTextSprite: ContainerComponent<
       $text.slice(0, $cursorIndex) + pastedText + $text.slice($cursorIndex);
     setText(text);
     $cursorIndex += pastedText.length;
+  };
+
+  const setCursorPosition = (pos: number) => {
+    pos = Math.max(0, Math.min(pos, $text.length));
+    $cursorIndex = pos;
+    calcCursorPosition();
+  };
+
+  const getCursorPosition = () => {
+    return $cursorIndex;
   };
 
   let removeOnKeyDown: () => void;
@@ -472,6 +489,8 @@ export const inputTextSprite: ContainerComponent<
     getText,
     setText,
     clear,
+    setCursorPosition,
+    getCursorPosition,
 
     setColor: $textSprite.setTint,
     getColor: $textSprite.getColor,

--- a/src/types/components/input-text-sprite.types.ts
+++ b/src/types/components/input-text-sprite.types.ts
@@ -44,6 +44,9 @@ export type PartialInputTextSpriteMutable = {
 
   setSelectionPadding: (padding: number) => void;
   getSelectionPadding: () => number;
+
+  setCursorPosition: (pos: number) => void;
+  getCursorPosition: () => number;
 } & Omit<
   PartialTextSpriteMutable,
   "setText" | "getText" | "$getTextBounds" | "$getCharacter"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export * from "./textures.types";
 export * from "./cursor.types";
 export * from "./envs.types";
 export * from "./tooltip.types";
+export * from "./keyboard.types";
 
 export * from "./components";
 export * from "./shapes";

--- a/src/types/keyboard.types.ts
+++ b/src/types/keyboard.types.ts
@@ -1,0 +1,4 @@
+export type KeyComboEvent = Pick<
+  KeyboardEvent,
+  "key" | "altKey" | "ctrlKey" | "shiftKey" | "metaKey"
+>;


### PR DESCRIPTION
feat(inputTextSprite): add key combination handlers for word navigation and deletion
- Implement Alt+ArrowLeft/ArrowRight to jump between words.
- Implement Alt+Backspace to delete the previous word.
- Implement Alt+Delete to delete the next word.
- Use getKeyCombination (based on KeyComboEvent) to detect these combinations.
- Create keyboard.types.ts to define KeyComboEvent for key combination handling.